### PR TITLE
str_replace(): Passing null to parameter #3 ($subject) of type array|…

### DIFF
--- a/src/LogViewer.php
+++ b/src/LogViewer.php
@@ -102,7 +102,7 @@ class LogViewer
 
     protected function formatPath($path)
     {
-        return str_replace(['../'], '', $path);
+        return $path ? str_replace(['../'], '', $path) : '';
     }
 
     /**


### PR DESCRIPTION
…string is deprecated